### PR TITLE
RSDK-6814 - Add Codec Detection and H265 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Prep linux
 ===
 
-* sudo apt install libswscale-dev libavcodec-dev
+* sudo apt install libswscale-dev libavcodec-dev libavformat-dev libavutil-dev
 
 Notes
 ===

--- a/decoder.go
+++ b/decoder.go
@@ -110,8 +110,8 @@ func convertCodec(cCodec C.int) videoCodec {
 
 // avError converts an AV error code to a AV error message string.
 func avError(avErr C.int) string {
-	var errbuf [1024]C.char
-	if C.av_strerror(avErr, &errbuf[0], 1024) < 0 {
+	var errbuf [C.AV_ERROR_MAX_STRING_SIZE]C.char
+	if C.av_strerror(avErr, &errbuf[0], C.AV_ERROR_MAX_STRING_SIZE) < 0 {
 		return fmt.Sprintf("Unknown error with code %d", avErr)
 	}
 	return C.GoString(&errbuf[0])

--- a/decoder.go
+++ b/decoder.go
@@ -17,18 +17,18 @@ import (
 #include <libavutil/avutil.h>
 
 int get_video_codec(AVFormatContext *avFormatCtx) {
-    int found_hevc = 0;
+    int found_h265 = 0;
     for (int i = 0; i < avFormatCtx->nb_streams; i++) {
         AVStream *stream = avFormatCtx->streams[i];
         AVCodecParameters *codecParams = stream->codecpar;
         if (codecParams->codec_id == AV_CODEC_ID_H264) {
             return AV_CODEC_ID_H264;
-        } else if (codecParams->codec_id == AV_CODEC_ID_HEVC) {
-            found_hevc = 1;
+        } else if (codecParams->codec_id == AV_CODEC_ID_H265) {
+            found_h265 = 1;
         }
     }
-    if (found_hevc) {
-        return AV_CODEC_ID_HEVC;
+    if (found_h265) {
+        return AV_CODEC_ID_H265;
     }
     return AV_CODEC_ID_NONE;
 }
@@ -91,7 +91,7 @@ func convertCodec(cCodec C.int) videoCodec {
 	switch cCodec {
 	case C.AV_CODEC_ID_H264:
 		return H264
-	case C.AV_CODEC_ID_HEVC:
+	case C.AV_CODEC_ID_H265:
 		return H265
 	default:
 		return Unknown
@@ -144,7 +144,7 @@ func newH264Decoder() (*decoder, error) {
 
 // newH265Decoder creates a new H265 decoder.
 func newH265Decoder() (*decoder, error) {
-	return newDecoder(C.AV_CODEC_ID_HEVC)
+	return newDecoder(C.AV_CODEC_ID_H265)
 }
 
 // close closes the decoder.

--- a/decoder.go
+++ b/decoder.go
@@ -15,6 +15,7 @@ import (
 #include <libswscale/swscale.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
+#include <stdlib.h>
 
 int get_video_codec(AVFormatContext *avFormatCtx) {
     int found_h265 = 0;

--- a/decoder.go
+++ b/decoder.go
@@ -17,6 +17,9 @@ import (
 #include <libavutil/avutil.h>
 #include <stdlib.h>
 
+// get_video_codec checks the provided AVFormatContext to find a supported video codec.
+// It prioritizes H264 over H265 if both are found.
+// If no supported codec is identified, it returns AV_CODEC_ID_NONE.
 int get_video_codec(AVFormatContext *avFormatCtx) {
     if (avFormatCtx == NULL) {
         return AV_CODEC_ID_NONE;

--- a/decoder.go
+++ b/decoder.go
@@ -18,10 +18,19 @@ import (
 #include <stdlib.h>
 
 int get_video_codec(AVFormatContext *avFormatCtx) {
+    if (avFormatCtx == NULL) {
+        return AV_CODEC_ID_NONE;
+    }
     int found_h265 = 0;
     for (int i = 0; i < avFormatCtx->nb_streams; i++) {
         AVStream *stream = avFormatCtx->streams[i];
+        if (stream == NULL) {
+            continue;
+        }
         AVCodecParameters *codecParams = stream->codecpar;
+        if (codecParams == NULL) {
+            continue;
+        }
         if (codecParams->codec_id == AV_CODEC_ID_H264) {
             return AV_CODEC_ID_H264;
         } else if (codecParams->codec_id == AV_CODEC_ID_H265) {


### PR DESCRIPTION
## Description

Unlike the [first PR](https://github.com/erh/viamrtsp/pull/1) which contains development packaging work, this aims to be the minimal change needed to add Codec Detection and H265 support. Build work can be introduced in subsequent PRs.

- This PR allows the module binary to handle both H264 and H265 codecs at runtime.
- If a given endpoint has tracks that support both codecs, H264 will take preference.

## Try Locally
### Build/Run on Linux:
- Make sure FFmpeg deps are installed: 
`sudo apt install libswscale-dev libavcodec-dev libavformat-dev libavutil-dev`
- Build go binary: 
`make bin/viamrtsp`
- Run as "local" module on Linux machine with FFmpeg deps installed.
```
    {
      "executable_path": "/path/to/viamrtsp",
      "name": "viamrtsp",
      "type": "local"
    }
```
- Configure component to listen to RTSP server endpoint.
```
    {
      "model": "erh:viamrtsp:rtsp-h264",
      "name": "ip-cam",
      "namespace": "rdk",
      "type": "camera",
      "attributes": {
        "rtsp_address": "rtsp://localhost:8554/live.stream"
      },
      "depends_on": []
    }
```
### Create Fake RTSP Camera:
- Download mediamtx:
`wget https://github.com/bluenviron/mediamtx/releases/download/v1.6.0/mediamtx_v1.6.0_linux_arm64v8.tar.gz`
- Extract:
`tar -xzf mediamtx_v1.6.0_linux_arm64v8.tar.gz`
- Run:
`./mediamtx`
- Run fake RTSP camera script:
`ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec libx264 -pix_fmt yuv420p -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream`
  - Replace codec with `libx265` for H265 feed.

## Tests
- Tested on RPI4 Bullseye (with FFmpeg dependencies installed).
    - fmpeg version `4.3.5`
- Tested on Macos.
    - ffmpeg version `6.1.1`
- `H264`, `H265`, `H264H`, and `H264B` streams working w/ physical IP Camera.
    - **Warning:** There is a known issue where toggling between h264h and h264b/h264 causes garbled video from the decoder. This PR does not address this.
- Endpoint without supported codec returns Unknown from getStreamInfo helper and prints error log correctly.
- avError fetches error messages correctly.
- `404` and `403` errors are handled gracefully.
- Reconfigures between H264/H265 endpoints work.

## Questions
- Currently as implemented the module will prefer H264 and only use H265 if that is the only codec ffmpeg reports as available for a given endpoint. Is that ok?
    - Do we want to add a codec preference to the attributes?
-  Which mode names we want to have in the module and what features should they support / not support? (`rtsp-h264`, `rtsp`, `rtsp-h265`)
    - We are keeping the rtsp-h264 as to not break existing model deployments.
    - Is it ok for rtsp-h264 to also support H265 if connected to a stream that only supports h265?
    - Do we want the h264 model to support h264 only and fail if connected to a h265 url?
- In order to support Codec Detection `libavformat` and `libavutil` dependencies have been added. Is this ok?
    - **Warning:** Module will not work without these additional deps are not installed on the local machine.
- What is the target platform that this module will run on in the wild (Pi4 or other)?
    - Are there any additional platforms other than Linux/arm64 we should focus testing on?