### PR TITLE
[RSDK-7079] Refactor models

### DIFF
--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -26,9 +26,11 @@ func realMain() error {
 		return err
 	}
 
-	err = myMod.AddModelFromRegistry(ctx, camera.API, viamrtsp.ModelH264)
-	if err != nil {
-		return err
+	for _, model := range viamrtsp.Models {
+		err = myMod.AddModelFromRegistry(ctx, camera.API, model)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = myMod.Start(ctx)

--- a/cmd/remote/cmd.go
+++ b/cmd/remote/cmd.go
@@ -39,7 +39,7 @@ func realMain() error {
 			{
 				Name:  os.Args[1],
 				API:   camera.API,
-				Model: viamrtsp.ModelH264,
+				Model: viamrtsp.Model,
 				Attributes: utils.AttributeMap{
 					"rtsp_address": os.Args[2],
 				},

--- a/cmd/remote/cmd.go
+++ b/cmd/remote/cmd.go
@@ -39,7 +39,7 @@ func realMain() error {
 			{
 				Name:  os.Args[1],
 				API:   camera.API,
-				Model: viamrtsp.Model,
+				Model: viamrtsp.ModelAgnostic,
 				Attributes: utils.AttributeMap{
 					"rtsp_address": os.Args[2],
 				},

--- a/decoder.go
+++ b/decoder.go
@@ -61,6 +61,7 @@ type videoCodec int
 
 const (
 	Unknown videoCodec = iota
+	Agnostic
 	H264
 	H265
 )

--- a/meta.json
+++ b/meta.json
@@ -2,11 +2,19 @@
   "module_id": "erh:viamrtsp",
   "visibility": "public",
   "url": "https://github.com/erh/viamrtsp",
-  "description": "module for rtsp, currently supports x264",
+  "description": "module for rtsp, currently supports x264 and x265",
   "models": [
     {
       "api": "rdk:component:camera",
+      "model": "erh:viamrtsp:rtsp"
+    },
+    {
+      "api": "rdk:component:camera",
       "model": "erh:viamrtsp:rtsp-h264"
+    },
+    {
+      "api": "rdk:component:camera",
+      "model": "erh:viamrtsp:rtsp-h265"
     }
   ],
   "entrypoint": "bin/viamrtsp"

--- a/rtsp.go
+++ b/rtsp.go
@@ -34,10 +34,18 @@ var ModelAgnostic = family.WithModel("rtsp")
 var ModelH264 = family.WithModel("rtsp-h264")
 var ModelH265 = family.WithModel("rtsp-h265")
 var Models = []resource.Model{ModelAgnostic, ModelH264, ModelH265}
-var modelToCodecMap = map[resource.Model]videoCodec{
-	ModelAgnostic: Unknown,
-	ModelH264:     H264,
-	ModelH265:     H265,
+
+func modelToCodec(model resource.Model) videoCodec {
+	switch model {
+	case ModelAgnostic:
+		return Unknown
+	case ModelH264:
+		return H264
+	case ModelH265:
+		return H265
+	default:
+		return Unknown
+	}
 }
 
 func init() {
@@ -377,7 +385,7 @@ func newRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 		u:      u,
 		logger: logger,
 	}
-	codecInfo := modelToCodecMap[conf.Model]
+	codecInfo := modelToCodec(conf.Model)
 	err = rtspCam.reconnectClient(codecInfo)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Context

https://viam.atlassian.net/browse/RSDK-7079

Adds `rtsp` model that streams from any available, supported codec

Makes `rtsp-h264` return error if detected codec is not h264

## Question
If we're adding a generic `rtsp` model, but also keeping `rtsp-h264`, should we add `rtsp-h265`? Plus more accordingly to new codecs we introduce?

Edit: I went ahead and added `rtsp-h265` as well— can remove it if bad

## Local Testing

1. `h264` fake stream with model `rtsp`: Success ✅
2. `h264` fake stream with model `rtsp-h264`: Success ✅
3. `h264` fake stream with model `rtsp-h265`: `resource build error: rpc error: code = Unknown desc = h265 track not found` ✅

5. `h265` fake stream with model `rtsp`: Success ✅
6. `h265` fake stream with model `rtsp-h264`: `resource build error: rpc error: code = Unknown desc = h264 track not found` ✅
7. `h265` fake stream with model `rtsp-h265`: Success ✅