### PR TITLE
bump-go-version-to-1.21

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: 1.21
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
https://github.com/erh/viamrtsp/pull/7 depends on go 1.21 (which is the currently supported go version in RDK) 

This updates CI to use go 1.21 so that that PR can pass tests