### PR TITLE
RSDK-7226 Add chunks flag to decoder

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -133,6 +133,9 @@ func newDecoder(codecID C.enum_AVCodecID) (*decoder, error) {
 		return nil, fmt.Errorf("avcodec_alloc_context3() failed")
 	}
 
+	// Set the decoder to handle partial frames
+	codecCtx.flags2 |= C.AV_CODEC_FLAG2_CHUNKS
+
 	res := C.avcodec_open2(codecCtx, codec, nil)
 	if res < 0 {
 		C.avcodec_close(codecCtx)

--- a/rtsp.go
+++ b/rtsp.go
@@ -263,11 +263,6 @@ func (rc *rtspCamera) initH264(tracks media.Medias, baseURL *url.URL) (err error
 
 		for _, nalu := range au {
 
-			if len(nalu) < 20 {
-				// TODO(ERH): this is probably wrong, but fixes a spam issue with "no frame!"
-				continue
-			}
-
 			// convert NALUs into RGBA frames
 			lastImage, err := rc.rawDecoder.decode(nalu)
 


### PR DESCRIPTION
## Description

The goal of this PR is to remove the 20 byte filter from h264 decoder loop by properly flagging the decoder to expect partial frames. This is needed since we are feeding NALs into the decoder instead of by frame boundary.

## Testing
- Tested that the decoder no longer logs `no frame!`.
- No regression to h264/h265 decoding performance or stability.

## Refs
- [AV_CODEC_FLAG2_CHUNKS](https://ffmpeg.org/doxygen/2.8/group__lavc__core.html#gabc5592664ff0686def0c2b41cfcc322d)