### PR TITLE
[RSDK-1155] remove build target conflicts

### DIFF
--- a/.canon.yaml
+++ b/.canon.yaml
@@ -1,14 +1,15 @@
-rtsp:
-    default: true
-    image_amd64: ghcr.io/viamrobotics/canon:amd64
-    image_arm64: ghcr.io/viamrobotics/canon:arm64
-    minimum_date: 2022-12-20T18:49:25.781750658Z
-    update_interval: 168h0m0s
-    persistent: false
-    user: testbot
-    group: testbot
+viam-rtsp:
+  default: true
+  image_amd64: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
+  image_arm64: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
+  image_arm: ghcr.io/viamrobotics/rdk-devenv:armhf-cache
+  minimum_date: 2023-10-26T20:00:00.0Z
+  update_interval: 168h0m0s
+  user: testbot
+  group: testbot
+  persistent: true
 
-viam-rdk-antique:
+viam-rtsp-antique:
     image_amd64: ghcr.io/viamrobotics/antique2:amd64-cache
     image_arm64: ghcr.io/viamrobotics/antique2:arm64-cache
     image_arm: ghcr.io/viamrobotics/antique2:armhf-cache

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
       run: ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -vcodec ${{ matrix.config.codec }} ${{ matrix.config.extra_ffmpeg_args }} -pix_fmt yuv420p -f rtsp -rtsp_transport tcp rtsp://0.0.0.0:8554/live.stream &
       
     - name: Build viamrtsp binary
-      run: make bin/viamrtsp
+      run: make
       
     - name: Install viam-server
       run: |
@@ -70,7 +70,7 @@ jobs:
             {
               "type": "local",
               "name": "viamrtsp",
-              "executable_path": "'$(realpath bin/viamrtsp)'"
+              "executable_path": "'$(realpath bin/Linux-x86_64/viamrtsp)'"
             }
           ]
         }' > "integration-test-config-${{ matrix.config.name }}.json"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ go.work
 
 viamrtsp
 module.tar.gz
+FFmpeg

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
+BIN_OUTPUT_PATH = bin/$(shell uname -s)-$(shell uname -m)
 UNAME_S ?= $(shell uname -s)
 UNAME_M ?= $(shell uname -m)
-FFMPEG_PREFIX ?= $(shell pwd)/FFmpeg/$(UNAME_S)-$(UNAME_M)
-FFMPEG_OPTS ?= --prefix=$(FFMPEG_PREFIX) \
+FFMPEG_TAG ?= n6.1
+FFMPEG_VERSION ?= $(shell pwd)/FFmpeg/$(FFMPEG_TAG)
+FFMPEG_VERSION_PLATFORM ?= $(FFMPEG_VERSION)/$(UNAME_S)-$(UNAME_M)
+FFMPEG_BUILD ?= $(FFMPEG_VERSION_PLATFORM)/build
+FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-static \
                --disable-shared \
                --disable-programs \
@@ -14,33 +18,30 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_PREFIX) \
                --enable-parser=h264 \
                --enable-parser=hevc
 
-CGO_LDFLAGS := -L$(FFMPEG_PREFIX)/lib
+CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib
 ifeq ($(UNAME_S),Linux)
 	CGO_LDFLAGS := "$(CGO_LDFLAGS) -l:libjpeg.a"
 endif
 
-.PHONY: build-ffmpeg test lint updaterdk module clean
+.PHONY: build-ffmpeg lint update-rdk module clean clean-all
 
-bin/viamrtsp: build-ffmpeg *.go cmd/module/*.go
-	PKG_CONFIG_PATH=$(FFMPEG_PREFIX)/lib/pkgconfig \
+$(BIN_OUTPUT_PATH)/viamrtsp: build-ffmpeg *.go cmd/module/*.go
+	PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig \
 		CGO_LDFLAGS=$(CGO_LDFLAGS) \
-		go build -o bin/viamrtsp cmd/module/cmd.go
-
-test:
-	go test
+		go build -o $(BIN_OUTPUT_PATH)/viamrtsp cmd/module/cmd.go
 
 lint:
 	gofmt -w -s .
 
-updaterdk:
+update-rdk:
 	go get go.viam.com/rdk@latest
 	go mod tidy
 
-FFmpeg:
-	git clone https://github.com/FFmpeg/FFmpeg.git --depth 1 --branch n6.1
+$(FFMPEG_VERSION_PLATFORM):
+	git clone https://github.com/FFmpeg/FFmpeg.git --depth 1 --branch $(FFMPEG_TAG) $(FFMPEG_VERSION_PLATFORM)
 
-$(FFMPEG_PREFIX): FFmpeg
-	cd FFmpeg && ./configure $(FFMPEG_OPTS) && $(MAKE) -j$(shell nproc) && $(MAKE) install
+$(FFMPEG_BUILD): $(FFMPEG_VERSION_PLATFORM)
+	cd $(FFMPEG_VERSION_PLATFORM) && ./configure $(FFMPEG_OPTS) && $(MAKE) -j$(shell nproc) && $(MAKE) install
 
 build-ffmpeg:
 ifeq ($(UNAME_S),Linux)
@@ -48,10 +49,14 @@ ifeq ($(UNAME_M),x86_64)
 	which nasm || (sudo apt update && sudo apt install -y nasm)
 endif
 endif
-	$(MAKE) $(FFMPEG_PREFIX)
+	$(MAKE) $(FFMPEG_BUILD)
 
-module: bin/viamrtsp
-	tar czf module.tar.gz bin/viamrtsp
+module: $(BIN_OUTPUT_PATH)/viamrtsp
+	tar czf $(BIN_OUTPUT_PATH)/module.tar.gz $(BIN_OUTPUT_PATH)/viamrtsp
 
 clean:
-	rm -rf FFmpeg bin/viamrtsp module.tar.gz
+	rm -rf $(BIN_OUTPUT_PATH)/viamrtsp $(BIN_OUTPUT_PATH)/module.tar.gz
+
+clean-all:
+	rm -rf FFmpeg
+	git clean -fxd

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ The binary is statically linked with [FFmpeg v6.1](https://github.com/FFmpeg/FFm
 * Build for Linux targets:
     * Install canon: `go install github.com/viamrobotics/canon@latest`
     * Startup canon dev container.
-        * Linux/Arm64: `canon -profile viam-rdk-antique -arch arm64`
-        * Linux/Amd64: `canon -profile viam-rdk-antique -arch amd64`
-    * Build binary: `make bin/viamrtsp`
+        * Linux/Arm64: `canon -profile viam-rtsp-antique -arch arm64`
+        * Linux/Amd64: `canon -profile viam-rtsp-antique -arch amd64`
+    * Build binary: `make`
 * Build for MacOS target:
-    * Build binary: `make bin/viamrtsp`
+    * Build binary: `make`
+* Binary will be in `bin/<OS>-<CPU>/viamrtsp`
 * Clean up build artifacts: `make clean`
+* Clean up all files not tracked in git: `make clean-all`
 
 
 Notes


### PR DESCRIPTION
Changes:
1. Update Makefile to support building concurrently for multiple platforms
1. Update .canon.yaml to have own unique names to prevent conflicting with rdk canon config & use same images as RDK
1. Add FFmpeg directory to .gitignore
1. Remove `make test` target as it didn't work (likely due to `CGO_LDFLAGS`). It is also unnecessary as `go test` works just fine when run outside of make

Manual Testing: (with vaim-server https://github.com/viamrobotics/rdk/releases/tag/v0.24.1)
- Change rtsp camera from outputting h264 -> h265 -> h264B -> H264H & confirm that the camera stream reconnects (does not apply for `erh:viamrtsp:rtsp-mjpeg`)
- for non  `erh:viamrtsp:rtsp` confirm that camera streams with the codec in their model name work & all others prevent them from booting

Models:
- [x] `erh:viamrtsp:rtsp`
- [x] `erh:viamrtsp:rtsp-h264`
- [x] `erh:viamrtsp:rtsp-h265`
- [x] `erh:viamrtsp:rtsp-mjpeg`

Platforms:
- [x] Macos aarm64 14.4.1
- [x] Ubuntu 22.04.4 amd64
- [x] RPI 4 (bullseye) arm64
- [x] RPI 5 (bookworm) arm64