### PR TITLE
RSDK-7354 Remove chunk flags from decoder

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -47,6 +47,11 @@ int get_video_codec(AVFormatContext *avFormatCtx) {
 */
 import "C"
 
+var (
+	// H264StartCode is start code byte sequence for H264/H265 NALs.
+	H2645StartCode = []uint8{0x00, 0x00, 0x00, 0x01}
+)
+
 // decoder is a generic FFmpeg decoder.
 type decoder struct {
 	codecCtx    *C.AVCodecContext

--- a/decoder.go
+++ b/decoder.go
@@ -156,9 +156,6 @@ func newDecoder(codecID C.enum_AVCodecID) (*decoder, error) {
 		return nil, fmt.Errorf("avcodec_alloc_context3() failed")
 	}
 
-	// Set the decoder to handle partial frames
-	codecCtx.flags2 |= C.AV_CODEC_FLAG2_CHUNKS
-
 	res := C.avcodec_open2(codecCtx, codec, nil)
 	if res < 0 {
 		C.avcodec_close(codecCtx)

--- a/decoder.go
+++ b/decoder.go
@@ -204,7 +204,7 @@ func (d *decoder) close() {
 }
 
 func (d *decoder) decode(nalu []byte) (image.Image, error) {
-	nalu = append([]uint8{0x00, 0x00, 0x00, 0x01}, []uint8(nalu)...)
+	nalu = append(H2645StartCode, []uint8(nalu)...)
 
 	// send frame to decoder
 	var avPacket C.AVPacket

--- a/rtsp.go
+++ b/rtsp.go
@@ -274,7 +274,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		au, err := rtpDec.Decode(pkt)
 		if err != nil {
 			if err != rtph264.ErrNonStartingPacketAndNoPrevious && err != rtph264.ErrMorePacketsNeeded {
-				rc.logger.Debugf("error decoding(1) h264 rstp stream err: %s", err.Error())
+				rc.logger.Errorf("error decoding(1) h264 rstp stream err: %s", err.Error())
 			}
 			return
 		}
@@ -287,7 +287,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 			nalu = append(nalu, au[2]...)
 			image, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
-				rc.logger.Debugf("error decoding(2) h264 rtsp stream  %s", err.Error())
+				rc.logger.Errorf("error decoding(2) h264 rtsp stream  %s", err.Error())
 				return
 			}
 			if image != nil {
@@ -308,7 +308,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 			// convert NALUs into RGBA frames
 			image, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
-				rc.logger.Debugf("error decoding(2) h264 rtsp stream  %s", err.Error())
+				rc.logger.Errorf("error decoding(2) h264 rtsp stream  %s", err.Error())
 				return
 			}
 			if image != nil {

--- a/rtsp.go
+++ b/rtsp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bluenviron/gortsplib/v4/pkg/format/rtph264"
 	"github.com/bluenviron/gortsplib/v4/pkg/format/rtph265"
 	"github.com/bluenviron/gortsplib/v4/pkg/liberrors"
+	"github.com/bluenviron/mediacommon/pkg/codecs/h264"
 	"github.com/google/uuid"
 
 	"github.com/erh/viamrtsp/formatprocessor"
@@ -289,6 +290,10 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		}
 
 		for _, nalu := range au {
+			typ := h264.NALUType(nalu[0] & 0x1F)
+			if typ == h264.NALUTypeSPS || typ == h264.NALUTypePPS {
+				continue
+			}
 			// convert NALUs into RGBA frames
 			image, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
@@ -570,7 +575,6 @@ func (rc *rtspCamera) Unsubscribe(ctx context.Context, id rtppassthrough.Subscri
 }
 
 func newRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger) (camera.Camera, error) {
-	SetLibAVLogLevelFatal()
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		logger.Error(err.Error())

--- a/rtsp.go
+++ b/rtsp.go
@@ -570,6 +570,7 @@ func (rc *rtspCamera) Unsubscribe(ctx context.Context, id rtppassthrough.Subscri
 }
 
 func newRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.Config, logger logging.Logger) (camera.Camera, error) {
+	SetLibAVLogLevelFatal()
 	newConf, err := resource.NativeConfig[*Config](conf)
 	if err != nil {
 		logger.Error(err.Error())
@@ -592,7 +593,6 @@ func newRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 		logger.Error(err.Error())
 		return nil, err
 	}
-	SetLibAVLogLevelFatal()
 	err = rc.reconnectClient(codecInfo)
 	if err != nil {
 		logger.Error(err.Error())

--- a/rtsp.go
+++ b/rtsp.go
@@ -283,7 +283,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		au, err := rtpDec.Decode(pkt)
 		if err != nil {
 			if err != rtph264.ErrNonStartingPacketAndNoPrevious && err != rtph264.ErrMorePacketsNeeded {
-				rc.logger.Errorf("error decoding(1) h264 rstp stream err: %s", err.Error())
+				rc.logger.Debugf("error decoding(1) h264 rstp stream err: %s", err.Error())
 			}
 			return
 		}
@@ -292,7 +292,7 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 			// convert NALUs into RGBA frames
 			image, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
-				rc.logger.Errorf("error decoding(2) h264 rtsp stream  %s", err.Error())
+				rc.logger.Debugf("error decoding(2) h264 rtsp stream  %s", err.Error())
 				return
 			}
 			if image != nil {
@@ -408,7 +408,7 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		au, err := rtpDec.Decode(pkt)
 		if err != nil {
 			if err != rtph265.ErrNonStartingPacketAndNoPrevious && err != rtph265.ErrMorePacketsNeeded {
-				rc.logger.Errorf("error decoding(1) h265 rstp stream err: %s", err.Error())
+				rc.logger.Debugf("error decoding(1) h265 rstp stream err: %s", err.Error())
 			}
 			return
 		}
@@ -416,7 +416,7 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		for _, nalu := range au {
 			lastImage, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
-				rc.logger.Errorf("error decoding(2) h265 rtsp stream err: %s", err.Error())
+				rc.logger.Debugf("error decoding(2) h265 rtsp stream err: %s", err.Error())
 				return
 			}
 
@@ -592,7 +592,7 @@ func newRTSPCamera(ctx context.Context, _ resource.Dependencies, conf resource.C
 		logger.Error(err.Error())
 		return nil, err
 	}
-
+	SetLibAVLogLevelFatal()
 	err = rc.reconnectClient(codecInfo)
 	if err != nil {
 		logger.Error(err.Error())


### PR DESCRIPTION
## Description

Even though the  `AV_CODEC_FLAG2_CHUNKS` is intended to be used when sending NALs into FFmpeg decoder - the functionality is not well-tested and is flaky when recovering from errors. See this[ issue](https://trac.ffmpeg.org/ticket/6815) that is 6 years old! 

~This PR adds a filter for `SPS` and `PPS` NALs to prevent `no frame!` log spam. We can safely skip these as we fill the decoder with SPS and PPS before accepting RTP packets.~

This PR packs SPS, PPS, and IDR frame NALs together before sending to the decoder. Also removes initial SPS/PPS setters and adds wait for iFrame when reading from h264 stream.

## Testing
- Changing between h264 profile levels 
  - h264b -> h264h ✅ 
  - h264h -> h264b ✅ 
  - h264 -> h264h ✅ 
  - h264h -> h264 ✅ 
  - h264 -> h264b ✅ 
  - h264b -> h264 ✅ 
 - Changing between h264->h265, h265->h264 ✅ 

 ## TODO:
- Figure out if SPS, PPS and IDR NALs are guaranteed to be grouped into a single AU from the gortsplib rtp decoder
- Get it working from mediamtx/fake-cam streams
