### PR TITLE
revert-RSDK-7226

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -85,9 +85,6 @@ func newDecoder(codecID C.enum_AVCodecID) (*decoder, error) {
 		return nil, fmt.Errorf("avcodec_alloc_context3() failed")
 	}
 
-	// Set the decoder to handle partial frames
-	codecCtx.flags2 |= C.AV_CODEC_FLAG2_CHUNKS
-
 	res := C.avcodec_open2(codecCtx, codec, nil)
 	if res < 0 {
 		C.avcodec_close(codecCtx)

--- a/rtsp.go
+++ b/rtsp.go
@@ -288,6 +288,10 @@ func (rc *rtspCamera) initH264(session *description.Session) (err error) {
 		}
 
 		for _, nalu := range au {
+			if len(nalu) < 20 {
+				// TODO(ERH): this is probably wrong, but fixes a spam issue with "no frame!"
+				continue
+			}
 			// convert NALUs into RGBA frames
 			image, err := rc.rawDecoder.decode(nalu)
 			if err != nil {


### PR DESCRIPTION
Reverts https://github.com/erh/viamrtsp/pull/12/files due to it causing https://viam.atlassian.net/browse/RSDK-7346 / https://viam.atlassian.net/browse/RSDK-7354

This is a temp fix to revert back to `v0.0.1` behavior. @seanavery is working on a more long term fix