### PR TITLE
RSDK-7330 - Make tests run against static FFmpeg build

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -34,9 +34,6 @@ jobs:
           exit 1
         fi
     
-    - name: Build ffmpeg and deps
-      run: make build-ffmpeg
-
     - name: Run linter and static checks
       run: make lint
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - '**/**.go'
       - 'Makefile'
+      - '.github/workflows/quality-checks.yml'
 
 jobs:
   quality-checks:

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - '**/**.go'
+      - 'Makefile'
 
 jobs:
   quality-checks:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ lint: gofmt tool-install
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
 test: build-ffmpeg
-	CGO_CFLAGS=$(CGO_CFLAGS) go test -race -v ./...
+	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go test -race -v ./...
 
 update-rdk:
 	go get go.viam.com/rdk@latest

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ else ifeq ($(SOURCE_OS),darwin)
 else
     NPROC ?= 1
 endif
+
 BIN_OUTPUT_PATH = bin/$(TARGET_OS)-$(TARGET_ARCH)
 TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 
@@ -46,7 +47,9 @@ FFMPEG_OPTS ?= --prefix=$(FFMPEG_BUILD) \
                --enable-network \
                --enable-parser=h264 \
                --enable-parser=hevc
+
 CGO_LDFLAGS := -L$(FFMPEG_BUILD)/lib
+CGO_CFLAGS := -I$(FFMPEG_BUILD)/include
 export PKG_CONFIG_PATH=$(FFMPEG_BUILD)/lib/pkgconfig
 
 # If we are building for android, we need to set the correct flags
@@ -100,8 +103,8 @@ lint: gofmt tool-install
 	export pkgs="`go list -f '{{.Dir}}' ./...`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml
 
-test:
-	go test -race -v ./...
+test: build-ffmpeg
+	CGO_CFLAGS=$(CGO_CFLAGS) go test -race -v ./...
 
 update-rdk:
 	go get go.viam.com/rdk@latest

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ tool-install:
 gofmt:
 	gofmt -w -s .
 
-lint: gofmt tool-install
+lint: gofmt tool-install build-ffmpeg
 	go mod tidy
 	export pkgs="`go list -f '{{.Dir}}' ./...`" && echo "$$pkgs" | xargs go vet -vettool=$(TOOL_BIN)/combined
 	GOGC=50 $(TOOL_BIN)/golangci-lint run -v --fix --config=./etc/.golangci.yaml


### PR DESCRIPTION
## Description

This fixes an issue on Darwin, where tests fail to pick up static FFmpeg build and rely on local homebrew installation instead. Added explicity `CGO_CFLAGS` setter since `PKG_CONFIG_PATH` was not linking correctly with go test 
commands.

Warning output:
```
cgo-gcc-prolog:180:11: warning: 'avcodec_close' is deprecated [-Wdeprecated-declarations]
/opt/homebrew/Cellar/ffmpeg/7.0/include/libavcodec/avcodec.h:2386:1: note: 'avcodec_close' has been explicitly marked deprecated here
/opt/homebrew/Cellar/ffmpeg/7.0/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
# github.com/erh/viamrtsp [github.com/erh/viamrtsp.test]
cgo-gcc-prolog:180:11: warning: 'avcodec_close' is deprecated [-Wdeprecated-declarations]
/opt/homebrew/Cellar/ffmpeg/7.0/include/libavcodec/avcodec.h:2386:1: note: 'avcodec_close' has been explicitly marked deprecated here
/opt/homebrew/Cellar/ffmpeg/7.0/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
# github.com/erh/viamrtsp.test
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
ld: warning: directory not found for option '-L/Users/sean/viamrtsp-new/FFmpeg/n6.1/darwin-arm64/build/lib'
```

## Tests
```
go clean -cache -testcache
make test
```
- make test on Darwin ✅ 
- quality checks ci (ubuntu-latest) ✅ 
- make test in canon Linux/Arm64 ✅ 
- make test in canon Linux/Amd64 ✅ 

~For some reason, make test is hanging (set a 10 min timer) in both antique and non-antique canon containers. Verified that this behavior occurs on main branch as well. Created separate ticket [RSDK-7798](https://viam.atlassian.net/browse/RSDK-7798) to address this issue.~ 