### PR TITLE
RSDK-7325 - Fix for dangling pointer segfaults

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -157,7 +157,7 @@ func (d *decoder) decode(nalu []byte) (image.Image, error) {
 	defer C.sws_freeContext(swsCtx)
 
 	// convert frame from YUV420 to RGB
-	stride := C.int(4 * d.srcFrame.width)
+	stride := 4 * d.srcFrame.width
 	res = C.sws_scale(swsCtx, frameData(d.srcFrame), frameLineSize(d.srcFrame),
 		0, d.srcFrame.height, (**C.uint8_t)(unsafe.Pointer(&pixData)), &stride)
 	if res < 0 {

--- a/decoder.go
+++ b/decoder.go
@@ -157,9 +157,9 @@ func (d *decoder) decode(nalu []byte) (image.Image, error) {
 	defer C.sws_freeContext(swsCtx)
 
 	// convert frame from YUV420 to RGB
-	lineSizes := frameLineSizeForRGBA(d.srcFrame.width)
+	stride := C.int(4 * d.srcFrame.width)
 	res = C.sws_scale(swsCtx, frameData(d.srcFrame), frameLineSize(d.srcFrame),
-		0, d.srcFrame.height, (**C.uint8_t)(unsafe.Pointer(&pixData)), &lineSizes[0])
+		0, d.srcFrame.height, (**C.uint8_t)(unsafe.Pointer(&pixData)), &stride)
 	if res < 0 {
 		return nil, errors.New("sws_scale() err")
 	}
@@ -168,14 +168,9 @@ func (d *decoder) decode(nalu []byte) (image.Image, error) {
 
 	return &image.RGBA{
 		Pix:    pixDataGo,
-		Stride: 4 * int(d.srcFrame.width),
+		Stride: int(stride),
 		Rect: image.Rectangle{
 			Max: image.Point{int(d.srcFrame.width), int(d.srcFrame.height)},
 		},
 	}, nil
-}
-
-// frameLineSizeForRGBA returns the line size array for an RGBA frame
-func frameLineSizeForRGBA(width C.int) [4]C.int {
-	return [4]C.int{4 * width, 0, 0, 0}
 }


### PR DESCRIPTION
## Description

This PR simply adds in a copy from the `dstFrame` in C memory to go bytes to avoid filling the go image with a pointer. The go garbage collector can now manage the lifetime of the frame data.

## Tests
- Confirmed that toggling back and for between h264/h265 and triggering EOF no longer results in occasional segfaults ✅ 
  - Here is an example log output toggling back and forth between h264/5,
  - EOF hits but no longer segfaults.

```
6/6/2024, 1:39:08 PM error robot_server.modmanager.process.viamrtsp_/home/viam/viamrtsp-malloc-final.StdErr pexec/managed_process.go:280 \_ [swscaler @ 0x7f2c3a5640] No accelerated colorspace conversion found from yuv420p to rgba.

6/6/2024, 1:39:08 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:166 reconnected to rtsp server url: rtsp://admin:GOSTadm1n@10.1.12.67:554 log_ts UTC

6/6/2024, 1:39:08 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:225 setting up H264 decoder log_ts UTC

6/6/2024, 1:39:08 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:187 reconnectClient called with codec: Agnostic log_ts UTC

6/6/2024, 1:39:08 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:154 The rtsp client encountered an error, trying to reconnect to rtsp://admin:GOSTadm1n@10.1.12.67:554, err: EOF log_ts UTC

6/6/2024, 1:38:53 PM error robot_server.modmanager.process.viamrtsp_/home/viam/viamrtsp-malloc-final.StdErr pexec/managed_process.go:280 \_ [swscaler @ 0x7f5024a1d0] No accelerated colorspace conversion found from yuv420p to rgba.

6/6/2024, 1:38:53 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:166 reconnected to rtsp server url: rtsp://admin:GOSTadm1n@10.1.12.67:554 log_ts UTC

6/6/2024, 1:38:53 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:230 setting up H265 decoder log_ts UTC

6/6/2024, 1:38:53 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:187 reconnectClient called with codec: Agnostic log_ts UTC

6/6/2024, 1:38:53 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:154 The rtsp client encountered an error, trying to reconnect to rtsp://admin:GOSTadm1n@10.1.12.67:554, err: EOF log_ts UTC

6/6/2024, 1:38:38 PM error robot_server.modmanager.process.viamrtsp_/home/viam/viamrtsp-malloc-final.StdErr pexec/managed_process.go:280 \_ [swscaler @ 0x7f34806500] No accelerated colorspace conversion found from yuv420p to rgba.

6/6/2024, 1:38:38 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:166 reconnected to rtsp server url: rtsp://admin:GOSTadm1n@10.1.12.67:554 log_ts UTC

6/6/2024, 1:38:38 PM info robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:225 setting up H264 decoder log_ts UTC

6/6/2024, 1:38:38 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:187 reconnectClient called with codec: Agnostic log_ts UTC

6/6/2024, 1:38:38 PM warn robot_server.viamrtsp.rdk:component:camera/ip-cam1 host/rtsp.go:154 The rtsp client encountered an error, trying to reconnect to rtsp://admin:GOSTadm1n@10.1.12.67:554, err: EOF log_ts UTC
```
- GetImage still works ✅ 
- profiling:
  - Checking performance by looking at the resulting FPS of the WebRTC video stream to the web app via the chrome://webrtc-internals page.
  - The following tests are using a RPI 4B.
  - h264 900x1080 30fps source (No significant performance hit) ✅ 
     -  PR:
![Screenshot 2024-06-03 at 3 16 58 PM](https://github.com/erh/viamrtsp/assets/12690131/edc95228-21b2-4a7c-af51-3787b399cf28)
      - main branch:
![Screenshot 2024-06-03 at 3 24 38 PM](https://github.com/erh/viamrtsp/assets/12690131/301f3ff9-2147-4a05-bbc3-255f3bee57fa)
  - h64 480x704 30fps source ✅ 
    - PR:
![Screenshot 2024-06-06 at 1 26 20 PM](https://github.com/erh/viamrtsp/assets/12690131/ebf3442a-1309-498c-88d1-f84db75fff87)
    - main branch:
![Screenshot 2024-06-06 at 1 30 22 PM](https://github.com/erh/viamrtsp/assets/12690131/3424d374-d7a8-42e1-8f15-493371d6237e)

## Refs
- [Golang Garbage Collector Guide](https://tip.golang.org/doc/gc-guide)
- [sws context](https://ffmpeg.org/doxygen/4.0/structSwsContext.html)
- [sws_scale](https://www.ffmpeg.org/doxygen/6.0/group__libsws.html#gae531c9754c9205d90ad6800015046d74)