### PR TITLE
Avoid the %w usage meant for wrapping errors with `fmt.Errorf`.

### DIFF
--- a/rtsp.go
+++ b/rtsp.go
@@ -430,7 +430,9 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		au, err := rtpDec.Decode(pkt)
 		if err != nil {
 			if !errors.Is(err, rtph265.ErrNonStartingPacketAndNoPrevious) && !errors.Is(err, rtph265.ErrMorePacketsNeeded) {
-				rc.logger.Debugf("error decoding(1) h265 rstp stream %w", err)
+				// This error is created with `github.com/pkg/errors`. Explicitly call `Error()` to
+				// avoid logging the stacktrace.
+				rc.logger.Debugw("error decoding(1) h265 rstp stream", "err", err.Error())
 			}
 			return
 		}
@@ -438,7 +440,9 @@ func (rc *rtspCamera) initH265(session *description.Session) (err error) {
 		for _, nalu := range au {
 			lastImage, err := rc.rawDecoder.decode(nalu)
 			if err != nil {
-				rc.logger.Debugf("error decoding(2) h265 rtsp stream err: %s", err.Error())
+				// This error is created with `github.com/pkg/errors`. Explicitly call `Error()` to
+				// avoid logging the stacktrace.
+				rc.logger.Debugw("error decoding(2) h265 rtsp stream", "err", err.Error())
 				return
 			}
 


### PR DESCRIPTION
This fixes the following output:
error decoding(1) h264 rstp stream %!w(*errors.errorString=&{invalid FU-A packet (non-starting)})