### PR TITLE
[RSDK-8197] [RSDK-8212] Fix ViamRTSP Performance Regression using pool (alternative)

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -152,8 +152,7 @@ func newH265Decoder(avFramePool *sync.Pool, logger logging.Logger) (*decoder, er
 // close closes the decoder.
 func (d *decoder) close() {
 	if d.dst != nil {
-		// no need to manually free; finalizers will handle it
-		d.dst = nil // explicitly set to nil to break the reference
+		d.dst = nil
 	}
 
 	if d.swsCtx != nil {

--- a/decoder.go
+++ b/decoder.go
@@ -223,10 +223,10 @@ func (d *decoder) decode(nalu []byte) (*imageAndPoolItem, error) {
 		if d.swsCtx == nil {
 			return nil, errors.New("sws_getContext() err")
 		}
-
-		dstFrameSize := C.av_image_get_buffer_size((int32)(d.dst.frame.format), d.dst.frame.width, d.dst.frame.height, 1)
-		d.dstFramePtr = (*[1 << 30]uint8)(unsafe.Pointer(d.dst.frame.data[0]))[:dstFrameSize:dstFrameSize]
 	}
+
+	dstFrameSize := C.av_image_get_buffer_size((int32)(d.dst.frame.format), d.dst.frame.width, d.dst.frame.height, 1)
+	d.dstFramePtr = (*[1 << 30]uint8)(unsafe.Pointer(d.dst.frame.data[0]))[:dstFrameSize:dstFrameSize]
 
 	// convert frame from YUV420 to RGB
 	res = C.sws_scale(d.swsCtx, frameData(d.src.frame), frameLineSize(d.src.frame),

--- a/decoder.go
+++ b/decoder.go
@@ -140,7 +140,7 @@ func (d *decoder) close() {
 }
 
 // allocateFrame allocates a bytes slice using frame info.
-func (d *decoder) allocateFrame() (*[]byte) {
+func (d *decoder) allocateFrame() *[]byte {
 	dstFrameSize := int(C.av_image_get_buffer_size((int32)(d.dstFrame.format), d.dstFrame.width, d.dstFrame.height, 1))
 	dataGo := make([]byte, dstFrameSize)
 	return &dataGo
@@ -206,7 +206,7 @@ func (d *decoder) decode(nalu []byte) (decoderOutput, error) {
 	if dstFrameSize < 0 {
 		return decoderOutput{}, errors.New("failed to get image buffer size")
 	}
-	
+
 	// ensure the slice from the pool is large enough
 	if cap(*dataGoPtr) < int(dstFrameSize) {
 		newSize := int(dstFrameSize)

--- a/decoder.go
+++ b/decoder.go
@@ -146,7 +146,7 @@ func newH265Decoder(avFramePool *sync.Pool, logger logging.Logger) (*decoder, er
 func (d *decoder) close() {
 	if d.dstFrame != nil {
 		// no need to manually free; finalizers will handle it
-		d.dstFrame = nil  // explicitly set to nil to break the reference
+		d.dstFrame = nil // explicitly set to nil to break the reference
 	}
 
 	if d.swsCtx != nil {

--- a/decoder.go
+++ b/decoder.go
@@ -13,58 +13,20 @@ import "C"
 import (
 	"fmt"
 	"image"
-	"sync"
 	"unsafe"
 
 	"github.com/pkg/errors"
 	"go.viam.com/rdk/logging"
 )
 
-// FrameWrapper wraps a C AVFrame and safely manages its memory in Go.
-type FrameWrapper struct {
-	frame *C.AVFrame
-	freed bool
-	mu    sync.Mutex
-}
-
-// newFrameWrapper creates a new FrameWrapper.
-func newFrameWrapper(frame *C.AVFrame) *FrameWrapper {
-	return &FrameWrapper{frame: frame}
-}
-
-// Data provides access to the underlying frame data
-func (fw *FrameWrapper) Data() []uint8 {
-	fw.mu.Lock()
-	defer fw.mu.Unlock()
-
-	if fw.freed {
-		panic("attempt to access freed memory")
-	}
-
-	size := C.av_image_get_buffer_size((int32)(fw.frame.format), fw.frame.width, fw.frame.height, 1)
-	return (*[1 << 30]uint8)(unsafe.Pointer(fw.frame.data[0]))[:size:size]
-}
-
-// Close releases the memory associated with the frame.
-func (fw *FrameWrapper) Close() {
-	fw.mu.Lock()
-	defer fw.mu.Unlock()
-
-	if fw.freed {
-		return
-	}
-
-	C.av_frame_free(&fw.frame)
-	fw.freed = true
-}
-
 // decoder is a generic FFmpeg decoder.
 type decoder struct {
 	logger      logging.Logger
 	codecCtx    *C.AVCodecContext
-	srcFrame    *FrameWrapper
+	srcFrame    *C.AVFrame
 	swsCtx      *C.struct_SwsContext
-	dstFrame    *FrameWrapper
+	dstFrame    *C.AVFrame
+	dstFramePtr []uint8
 }
 
 type videoCodec int
@@ -147,7 +109,7 @@ func newDecoder(codecID C.enum_AVCodecID, logger logging.Logger) (*decoder, erro
 	return &decoder{
 		logger:   logger,
 		codecCtx: codecCtx,
-		srcFrame: newFrameWrapper(srcFrame),
+		srcFrame: srcFrame,
 	}, nil
 }
 
@@ -161,23 +123,18 @@ func newH265Decoder(logger logging.Logger) (*decoder, error) {
 	return newDecoder(C.AV_CODEC_ID_H265, logger)
 }
 
-// close closes the decoder and cleans up C resources.
+// close closes the decoder.
 func (d *decoder) close() {
 	if d.dstFrame != nil {
-		d.dstFrame.Close()
+		C.av_frame_free(&d.dstFrame)
 	}
 
 	if d.swsCtx != nil {
 		C.sws_freeContext(d.swsCtx)
 	}
 
-	if d.srcFrame != nil {
-		d.srcFrame.Close()
-	}
-
-	if d.codecCtx != nil {
-		C.avcodec_close(d.codecCtx)
-	}
+	C.av_frame_free(&d.srcFrame)
+	C.avcodec_close(d.codecCtx)
 }
 
 func (d *decoder) decode(nalu []byte) (image.Image, error) {
@@ -193,50 +150,55 @@ func (d *decoder) decode(nalu []byte) (image.Image, error) {
 		return nil, nil
 	}
 
-	res = C.avcodec_receive_frame(d.codecCtx, d.srcFrame.frame)
+	// receive frame if available
+	res = C.avcodec_receive_frame(d.codecCtx, d.srcFrame)
 	if res < 0 {
 		return nil, nil
 	}
 
-	if d.dstFrame == nil || d.dstFrame.frame.width != d.srcFrame.frame.width || d.dstFrame.frame.height != d.srcFrame.frame.height {
+	// if frame size has changed, allocate needed objects
+	if d.dstFrame == nil || d.dstFrame.width != d.srcFrame.width || d.dstFrame.height != d.srcFrame.height {
 		if d.dstFrame != nil {
-			d.dstFrame.Close()
+			C.av_frame_free(&d.dstFrame)
 		}
 
 		if d.swsCtx != nil {
 			C.sws_freeContext(d.swsCtx)
 		}
 
-		dstFrame := C.av_frame_alloc()
-		dstFrame.format = C.AV_PIX_FMT_RGBA
-		dstFrame.width = d.srcFrame.frame.width
-		dstFrame.height = d.srcFrame.frame.height
-		dstFrame.color_range = C.AVCOL_RANGE_JPEG
-		res = C.av_frame_get_buffer(dstFrame, 1)
+		d.dstFrame = C.av_frame_alloc()
+		d.dstFrame.format = C.AV_PIX_FMT_RGBA
+		d.dstFrame.width = d.srcFrame.width
+		d.dstFrame.height = d.srcFrame.height
+		d.dstFrame.color_range = C.AVCOL_RANGE_JPEG
+		res = C.av_frame_get_buffer(d.dstFrame, 1)
 		if res < 0 {
 			return nil, errors.New("av_frame_get_buffer() err")
 		}
 
-		d.dstFrame = newFrameWrapper(dstFrame)
-
-		d.swsCtx = C.sws_getContext(d.srcFrame.frame.width, d.srcFrame.frame.height, C.AV_PIX_FMT_YUV420P,
-			d.dstFrame.frame.width, d.dstFrame.frame.height, (int32)(d.dstFrame.frame.format), C.SWS_BILINEAR, nil, nil, nil)
+		d.swsCtx = C.sws_getContext(d.srcFrame.width, d.srcFrame.height, C.AV_PIX_FMT_YUV420P,
+			d.dstFrame.width, d.dstFrame.height, (int32)(d.dstFrame.format), C.SWS_BILINEAR, nil, nil, nil)
 		if d.swsCtx == nil {
 			return nil, errors.New("sws_getContext() err")
 		}
+
+		dstFrameSize := C.av_image_get_buffer_size((int32)(d.dstFrame.format), d.dstFrame.width, d.dstFrame.height, 1)
+		d.dstFramePtr = (*[1 << 30]uint8)(unsafe.Pointer(d.dstFrame.data[0]))[:dstFrameSize:dstFrameSize]
 	}
 
-	res = C.sws_scale(d.swsCtx, frameData(d.srcFrame.frame), frameLineSize(d.srcFrame.frame),
-		0, d.srcFrame.frame.height, frameData(d.dstFrame.frame), frameLineSize(d.dstFrame.frame))
+	// convert frame from YUV420 to RGB
+	res = C.sws_scale(d.swsCtx, frameData(d.srcFrame), frameLineSize(d.srcFrame),
+		0, d.srcFrame.height, frameData(d.dstFrame), frameLineSize(d.dstFrame))
 	if res < 0 {
 		return nil, errors.New("sws_scale() err")
 	}
 
+	// embed frame into an image.Image
 	return &image.RGBA{
-		Pix:    d.dstFrame.Data(),
-		Stride: 4 * (int)(d.dstFrame.frame.width),
+		Pix:    d.dstFramePtr,
+		Stride: 4 * (int)(d.dstFrame.width),
 		Rect: image.Rectangle{
-			Max: image.Point{(int)(d.dstFrame.frame.width), (int)(d.dstFrame.frame.height)},
+			Max: image.Point{(int)(d.dstFrame.width), (int)(d.dstFrame.height)},
 		},
 	}, nil
 }

--- a/rtsp.go
+++ b/rtsp.go
@@ -98,7 +98,7 @@ type (
 	}
 	imageAndPoolItem struct {
 		img      image.Image
-		poolItem *AVFrameWrapper
+		poolItem *avFrameWrapper
 	}
 )
 

--- a/rtsp.go
+++ b/rtsp.go
@@ -97,7 +97,7 @@ type (
 		buf *rtppassthrough.Buffer
 	}
 	decoderOutput struct {
-		img      image.Image
+		img image.Image
 		// The decoder also outputs a pool item to put back into the pool
 		// after we are done using them.
 		poolItem *[]byte

--- a/rtsp.go
+++ b/rtsp.go
@@ -502,7 +502,7 @@ func (rc *rtspCamera) initMJPEG(session *description.Session) error {
 			return
 		}
 
-		// manually set nil for avFramePtr since we don't use a pool for mjpeg frames
+		// manually set nil since we don't use a pool for mjpeg frames
 		rc.latestOutput.Store(&decoderOutput{img: img, poolItem: nil})
 	})
 


### PR DESCRIPTION
This is an alternative solution to https://github.com/erh/viamrtsp/pull/41

Instead of using garbage collection `finalizer` to clean up C memory. This approach moves away from putting C memory pointer items on the pool, and instead uses go `*[]bytes`. This type of pool reduces the overhead of mallocing, but still needs to `memcpy` from the C-owned blocks to Go-owned blocks. The tradeoff here is that instead of having to rely on unreliable finalizers to clean up C memory (see [here](https://archive.is/5NLGo)), we can rely on the Go garbage collector to do so for us with Go memory, but incur the overhead of copying.

Testing on a RPI4 Bookworm, this approach can support 5 concurrent streams. It starts noticeably lagging more at 6. Not quite a full restoration to the pre-regression performance.